### PR TITLE
feat(SR): Support SCOORD3D point annotations and IDC bounding box annotations

### DIFF
--- a/src/convertAnnotations.ts
+++ b/src/convertAnnotations.ts
@@ -1,0 +1,239 @@
+import getClosestInstanceInfoRelativeToPoint, {
+  getPointProjection,
+} from './getClosestInstanceInfoRelativeToPoint';
+import { utilities as csUtils } from '@cornerstonejs/core';
+
+function toArray(x) {
+  return Array.isArray(x) ? x : [x];
+}
+
+const codeMeaningEquals = codeMeaningName => {
+  return contentItem => {
+    return contentItem.ConceptNameCodeSequence.CodeMeaning === codeMeaningName;
+  };
+};
+
+function uid() {
+  let uid = '2.25.' + Math.floor(1 + Math.random() * 9);
+  for (let index = 0; index < 38; index++) {
+    uid = uid + Math.floor(Math.random() * 10);
+  }
+  return uid;
+}
+
+const TRACKING_IDENTIFIER = 'Tracking Identifier';
+const REPORT = 'Imaging Measurements';
+const GROUP = 'Measurement Group';
+const TRACKING_IDENTIFIER_CODE = '112040';
+
+export function convertPolylineAnnotationsInMeasurementGroups(measurementGroup, displaySets) {
+  const referencedImages = [];
+  const cornerstoneTag = 'Cornerstone3DTools@^0.1.0';
+  const toolName = 'PlanarFreehandROI';
+  const measurementGroupContentSequence = toArray(measurementGroup.ContentSequence);
+  const SCOORDContentItems = measurementGroupContentSequence.filter(
+    group => group.ValueType === 'SCOORD'
+  );
+  const NUMContentItems = measurementGroupContentSequence.filter(
+    group => group.ValueType === 'NUM'
+  );
+  if (!NUMContentItems.length) {
+    if (SCOORDContentItems.length) {
+      measurementGroupContentSequence[Object.keys(measurementGroupContentSequence).length] = {
+        ConceptNameCodeSequence: {
+          ...SCOORDContentItems[0].ConceptNameCodeSequence,
+        },
+        ContentSequence: SCOORDContentItems,
+        ValueType: 'NUM',
+      };
+      // add TrackingIdentifier in the new measurement group
+      const TrackingIdentifierGroup = measurementGroupContentSequence.find(
+        contentItem => contentItem.ConceptNameCodeSequence.CodeMeaning === TRACKING_IDENTIFIER
+      );
+
+      const mappedTrackingIdentifier = `${cornerstoneTag}:${toolName}`;
+      TrackingIdentifierGroup.TextValue = mappedTrackingIdentifier;
+
+      SCOORDContentItems[0].ContentSequence[0].ReferencedSOPSequence.forEach(item => {
+        const { ReferencedSOPClassUID, ReferencedSOPInstanceUID } = item;
+        referencedImages.push({
+          ReferencedSOPClassUID,
+          ReferencedSOPInstanceUID,
+        });
+      });
+    }
+  }
+  return referencedImages;
+}
+
+export function convertSCOORD3DAnnotationsInMeasurementGroups(measurementGroup, displaySets) {
+  const cornerstoneTag = 'Cornerstone3DTools@^0.1.0';
+  const toolName = 'ArrowAnnotate';
+  const newlyGeneratedMeasurementGroups = [];
+  const newlyFoundReferencedImages = [];
+  const measurementGroupContentSequence = toArray(measurementGroup.ContentSequence);
+  const SCOORD3DContentItems = measurementGroupContentSequence.filter(
+    group => group.ValueType === 'SCOORD3D'
+  );
+  const NUMContentItems = measurementGroupContentSequence.filter(
+    group => group.ValueType === 'NUM'
+  );
+  if (!NUMContentItems.length) {
+    if (SCOORD3DContentItems.length) {
+      // search SCOORD3D item
+      let scoord3DIndex = -1;
+      for (let i = 0; i < measurementGroupContentSequence.length; i++) {
+        if (measurementGroupContentSequence[i].ValueType === 'SCOORD3D') {
+          scoord3DIndex = i;
+          break;
+        }
+      }
+      // search TrackingIdentifier Item item
+      let trackIDIndex = -1;
+      for (let i = 0; i < measurementGroupContentSequence.length; i++) {
+        if (
+          measurementGroupContentSequence[i].ConceptNameCodeSequence.CodeValue ===
+          TRACKING_IDENTIFIER_CODE
+        ) {
+          trackIDIndex = i;
+          break;
+        }
+      }
+
+      const measurementGroupMatrix = Object.assign({}, measurementGroup);
+      const contentSequenceMatrix = [...measurementGroup.ContentSequence];
+      const SCOORD3DContentItemsClone = [...SCOORD3DContentItems];
+      const trackingIdentifierContentItemsClone = {
+        ...measurementGroupContentSequence[trackIDIndex],
+      };
+      const frameOfReference = SCOORD3DContentItems[0].ReferencedFrameOfReferenceUID;
+      const closestInstanceInfos = getClosestInstanceInfoRelativeToPoint(
+        SCOORD3DContentItems[0].GraphicData,
+        frameOfReference,
+        displaySets
+      );
+
+      for (let i = 0; i < closestInstanceInfos.length; i++) {
+        const closestInstanceInfo = closestInstanceInfos[i];
+        const SOPClassUID = closestInstanceInfo.instance.SOPClassUID;
+        const SOPInstanceUID = closestInstanceInfo.instance.SOPInstanceUID;
+        const point = getPointProjection(
+          SCOORD3DContentItems[0].GraphicData,
+          closestInstanceInfo.instance
+        );
+        const imagePoint = csUtils.worldToImageCoords(closestInstanceInfo.instance.imageId, point);
+
+        const newSCOORDContentItem = {
+          RelationshipType: 'CONTAINS',
+          ValueType: 'SCOORD',
+          ConceptNameCodeSequence: {
+            CodeValue: '111030',
+            CodingSchemeDesignator: 'DCM',
+            CodeMeaning: 'Image Region',
+          },
+          ContentSequence: {
+            ReferencedSOPSequence: {
+              ReferencedSOPClassUID: SOPClassUID,
+              ReferencedSOPInstanceUID: SOPInstanceUID,
+            },
+            RelationshipType: 'SELECTED FROM',
+            ValueType: 'IMAGE',
+            ConceptNameCodeSequence: {
+              CodeValue: '111040',
+              CodingSchemeDesignator: 'DCM',
+              CodeMeaning: 'Original Source',
+            },
+          },
+          PixelOriginInterpretation: 'VOLUME',
+          GraphicData: imagePoint,
+          GraphicType: 'POINT',
+        };
+        newlyFoundReferencedImages.push({
+          ReferencedSOPClassUID: SOPClassUID,
+          ReferencedSOPInstanceUID: SOPInstanceUID,
+        });
+        let contentSequence;
+        if (i === 0) {
+          measurementGroupContentSequence[Object.keys(measurementGroupContentSequence).length] = {
+            ConceptNameCodeSequence: SCOORD3DContentItems[0].ConceptNameCodeSequence,
+            ContentSequence: newSCOORDContentItem,
+            ValueType: 'NUM',
+          };
+          contentSequence = measurementGroupContentSequence;
+          SCOORD3DContentItems[0].ValueType = 'SCOORD';
+          SCOORD3DContentItems[0].ContentSequence = {
+            ...SCOORD3DContentItems[0].ContentSequence,
+            ReferencedSOPSequence: {
+              ReferencedSOPClassUID: SOPClassUID,
+              ReferencedSOPInstanceUID: SOPInstanceUID,
+            },
+          };
+        } else {
+          const measurementGroupClone = Object.assign({}, measurementGroupMatrix);
+          measurementGroupClone.ContentSequence = [...contentSequenceMatrix];
+          contentSequence = toArray(measurementGroupClone.ContentSequence);
+          contentSequence[Object.keys(contentSequence).length] = {
+            ConceptNameCodeSequence: SCOORD3DContentItems[0].ConceptNameCodeSequence,
+            ContentSequence: newSCOORDContentItem,
+            ValueType: 'NUM',
+          };
+          contentSequence[scoord3DIndex] = { ...SCOORD3DContentItemsClone[0] };
+          contentSequence[scoord3DIndex].ContentSequence = {
+            ...SCOORD3DContentItems[0].ContentSequence,
+            ReferencedSOPSequence: {
+              ReferencedSOPClassUID: SOPClassUID,
+              ReferencedSOPInstanceUID: SOPInstanceUID,
+            },
+          };
+          contentSequence[trackIDIndex] = {
+            ...trackingIdentifierContentItemsClone,
+            UID: uid(),
+          };
+
+          newlyGeneratedMeasurementGroups.push(measurementGroupClone);
+        }
+        // add TrackingIdentifier in the new measurement group
+        const TrackingIdentifierGroup = contentSequence.find(
+          contentItem => contentItem.ConceptNameCodeSequence.CodeMeaning === TRACKING_IDENTIFIER
+        );
+
+        const mappedTrackingIdentifier = `${cornerstoneTag}:${toolName}`;
+        TrackingIdentifierGroup.TextValue = mappedTrackingIdentifier;
+      }
+    }
+  }
+  return { newlyGeneratedMeasurementGroups, newlyFoundReferencedImages };
+}
+
+export function convertAnnotations(dataset, displaySetService) {
+  // Get the displaySets loaded
+  const displaySets = [...displaySetService.getDisplaySetCache().values()];
+  // Identify the Imaging Measurements
+  const imagingMeasurementContent = toArray(dataset.ContentSequence).find(
+    codeMeaningEquals(REPORT)
+  );
+
+  let additionalMeasurementGroups = [];
+  let referencedImages = [];
+  // Retrieve the Measurements themselves
+  const measurementGroups = toArray(imagingMeasurementContent.ContentSequence).filter(
+    codeMeaningEquals(GROUP)
+  );
+  measurementGroups.forEach(measurementGroup => {
+    const result = convertSCOORD3DAnnotationsInMeasurementGroups(measurementGroup, displaySets);
+    if (result) {
+      const { newlyGeneratedMeasurementGroups, newlyFoundReferencedImages } = result;
+      additionalMeasurementGroups = additionalMeasurementGroups.concat(
+        newlyGeneratedMeasurementGroups
+      );
+      referencedImages = referencedImages.concat(newlyFoundReferencedImages);
+    }
+    const newReferencedImages = convertPolylineAnnotationsInMeasurementGroups(
+      measurementGroup,
+      displaySets
+    );
+    referencedImages = referencedImages.concat(newReferencedImages);
+  });
+  additionalMeasurementGroups.map(group => imagingMeasurementContent.ContentSequence.push(group));
+  return referencedImages;
+}

--- a/src/getClosestInstanceInfoRelativeToPoint.ts
+++ b/src/getClosestInstanceInfoRelativeToPoint.ts
@@ -1,0 +1,107 @@
+import { vec3 } from 'gl-matrix';
+
+/**
+ * Calculates the plane normal given the image orientation vector
+ * @param imageOrientation
+ * @returns
+ */
+function calculatePlaneNormal(imageOrientation) {
+  const rowCosineVec = vec3.fromValues(
+    imageOrientation[0],
+    imageOrientation[1],
+    imageOrientation[2]
+  );
+  const colCosineVec = vec3.fromValues(
+    imageOrientation[3],
+    imageOrientation[4],
+    imageOrientation[5]
+  );
+  return vec3.cross(vec3.create(), rowCosineVec, colCosineVec);
+}
+
+/**
+ * Calculates the projection of a world point into an image plane
+ * @param point
+ * @param instance
+ */
+export function getPointProjection(point, instance) {
+  const reference = instance.ImagePositionPatient;
+  const imageOrientation = instance.ImageOrientationPatient;
+  const scanAxisNormal = calculatePlaneNormal(imageOrientation);
+
+  // gets the world point relative to image plane reference
+  const subtractedPoint = vec3.create();
+  vec3.subtract(subtractedPoint, point, reference);
+
+  // calculate the distance and 'lower' the world point to plane
+  const distance = Math.abs(vec3.dot(subtractedPoint, scanAxisNormal));
+  const pointProjected = vec3.create();
+  vec3.scaleAndAdd(pointProjected, point, scanAxisNormal, -distance);
+  return [pointProjected[0], pointProjected[1], pointProjected[2]];
+}
+/**
+ * Calculates the minimum distance between a world point and an image plane
+ * @param point
+ * @param instance
+ * @returns
+ */
+function planeDistance(point, instance) {
+  const imageOrientation = instance.ImageOrientationPatient;
+  const imagePositionPatient = instance.ImagePositionPatient;
+  const scanAxisNormal = calculatePlaneNormal(imageOrientation);
+  const [A, B, C] = scanAxisNormal;
+
+  const D =
+    -A * imagePositionPatient[0] - B * imagePositionPatient[1] - C * imagePositionPatient[2];
+
+  return Math.abs(A * point[0] + B * point[1] + C * point[2] + D); // Denominator is sqrt(A**2 + B**2 + C**2) which is 1 as its a normal vector
+}
+
+/**
+ * Gets the closest instance of a displaySet related to a given world point
+ * @param targetPoint            target world point
+ * @param displaySet             displaySet to check
+ * @param closestInstanceInfo    last closest instance
+ * @returns
+ */
+function getClosestInstanceRelativeToPoint(targetPoint, displaySet, closestInstanceInfos) {
+  // todo: this does not assume orientation yet, but that can be added later
+  const displaySetInstanceUID = displaySet.displaySetInstanceUID;
+  return displaySet.instances.reduce((closestInstanceInfos, instance) => {
+    const distance = planeDistance(targetPoint, instance);
+
+    // the threshold is half of the slicethickness or 5 mm
+    const threshold = 0.1; //(instance?.SliceThickness || 5) / 2;
+
+    if (distance < threshold) {
+      const closestInstanceInfo = {
+        distance,
+        instance,
+        displaySetInstanceUID,
+      };
+      closestInstanceInfos.push(closestInstanceInfo);
+    }
+    return closestInstanceInfos;
+  }, closestInstanceInfos);
+}
+
+/**
+ * Return the information of the closest instance respective to a target world point
+ * of all displaySets that shares a given FrameOfReferenceUID
+ * @param targetPoint
+ * @param displaySets
+ * @returns
+ */
+export default function getClosestInstanceInfoRelativeToPoint(
+  targetPoint,
+  frameOfReferenceUID,
+  displaySets
+) {
+  return displaySets.reduce((closestInstanceInfos, displaySet) => {
+    if (displaySet.instance.FrameOfReferenceUID === frameOfReferenceUID) {
+      return getClosestInstanceRelativeToPoint(targetPoint, displaySet, closestInstanceInfos);
+    } else {
+      return closestInstanceInfos;
+    }
+  }, []);
+}

--- a/src/index.js
+++ b/src/index.js
@@ -2,6 +2,7 @@ import { hotkeys } from '@ohif/core';
 import toolbarButtons from './toolbarButtons.js';
 import { id } from './id.js';
 import initToolGroups from './initToolGroups.js';
+import { convertAnnotations } from './convertAnnotations';
 
 // Allow this mode by excluding non-imaging modalities such as SR, SEG
 // Also, SM is not a simple imaging modalities, so exclude it.
@@ -83,7 +84,14 @@ function modeFactory() {
         toolGroupService,
         panelService,
         segmentationService,
+        customizationService,
       } = servicesManager.services;
+
+      const dicomSrExtensionCustomizations = {
+        id: 'dicomSrExtensionCustomizations',
+        convertAnnotations,
+      };
+      customizationService.addModeCustomizations([dicomSrExtensionCustomizations]);
 
       measurementService.clearMeasurements();
 


### PR DESCRIPTION
This PR adds the support for SCOORD3D point annotations and IDC bounding box annotations. It depends on OHIF PR https://github.com/OHIF/Viewers/pull/3631, that enables modes to inject customizations in the dicom sr extension. It defines a function that will convert IDC SR annotations to OHIF/Cornerstone compatible ones.

For now, just POINT SCOORD3D annotations and IDC SR bounding boxes are supported, but other annotations will be included in near future. This PR handles SCOORD3D point annotations by projecting them to all images that are distant less than a threshold value, actually set to 0.1. It is important to note that one SCOORD3d can create multiple SCOORD annotations.